### PR TITLE
fix: correct regex pattern for URL parameter replacement

### DIFF
--- a/helpers/http.py
+++ b/helpers/http.py
@@ -68,7 +68,7 @@ def makeMessage(self, messageInfo, removeOrNot, authorizeOrNot):
                             paramKey, paramValue = param.split('=', 1)
                             paramKey = paramKey.strip()
                             paramValue = paramValue.strip()
-                            pattern = r'([?&]){}=[^&\s]*'.format(re.escape(paramKey))
+                            pattern = r'(^|[?&]){}=[^&]*'.format(re.escape(paramKey))
                             replacement = r'\1{}={}'.format(paramKey, paramValue)
                             newQuery = re.sub(pattern, replacement, query, count=0, flags=re.DOTALL)
                             if newQuery != query:


### PR DESCRIPTION
# 修复URL参数替换正则表达式以支持查询字符串首个参数

## 问题描述

URL参数替换功能无法替换出现在查询字符串开头的参数。这个问题是由于当前的正则表达式模式 `([?&])参数名=[^&\s]*` 只能匹配前面有 `?` 或 `&` 字符的参数，但查询字符串的第一个参数前面没有前置分隔符。

### 问题示例

**输入：**
- URL: `GET /vul/overpermission/op1/op1_mem.php?username=lucy&submit=%E7%82%B9%E5%87%BB%E6%9F%A5%E7%9C%8B%E4%B8%AA%E4%BA%BA%E4%BF%A1%E6%81%AF HTTP/1.1`
- 替换参数: `username=lili`

**期望结果:** 参数 `username` 应该从 `lucy` 改为 `lili`
**实际结果:** 没有替换发生 - URL保持不变

## 根本原因分析

问题出现在 `makeMessage` 函数处理URL的过程中：

### URL处理步骤：
1. **原始HTTP请求行:**
   ```
   GET /vul/overpermission/op1/op1_mem.php?username=lucy&submit=%E7%82%B9%E5%87%BB%E6%9F%A5%E7%9C%8B%E4%B8%AA%E4%BA%BA%E4%BF%A1%E6%81%AF HTTP/1.1
   ```

2. **分割HTTP请求行:**
   ```python
   method, url, protocol = requestLine.split(" ", 2)
   # url = '/vul/overpermission/op1/op1_mem.php?username=lucy&submit=...'
   ```

3. **关键步骤 - 将URL分割为路径和查询字符串:**
   ```python
   path_and_query = url.split("?", 1)
   path = path_and_query[0]  # '/vul/overpermission/op1/op1_mem.php'
   query = path_and_query[1] if len(path_and_query) > 1 else ""
   # query = 'username=lucy&submit=...'  注意：开头没有'?'了
   ```

### 核心问题
**URL分割后，查询字符串变成了 `username=lucy&submit=...` - 开头不再包含 `?` 字符**

但是，原始的正则表达式模式 `([?&]){}=[^&\s]*` 期望匹配：
- `?username=xxx` 或 `&username=xxx`

实际的查询字符串是：
- `username=lucy&...` (开头没有 `?` 或 `&`)

因此，正则表达式无法匹配查询字符串中的第一个参数。

## 解决方案

将正则表达式模式从：
```python
pattern = r'([?&]){}=[^&\s]*'.format(re.escape(paramKey))
```

修改为：
```python
pattern = r'(^|[?&]){}=[^&]*'.format(re.escape(paramKey))
```

### 关键改动：
1. `([?&])` → `(^|[?&])` - 添加字符串开始锚点以匹配第一个参数
2. `[^&\s]*` → `[^&]*` - 简化参数值匹配（移除空白字符限制以更好地支持特殊参数值）

#### 移除`\s`限制的具体例子：

**场景：参数值包含空格的情况**
```
查询字符串: "username=john smith&password=secret&submit=login"
```

- **原始模式** `[^&\s]*`: 匹配到 `username=john`
  - 遇到空格就停止匹配
  - 替换结果: `username=REPLACED smith&password=secret&submit=login` (不完整)

- **新模式** `[^&]*`: 匹配到 `username=john smith`  
  - 完整匹配到下一个`&`为止
  - 替换结果: `username=REPLACED&password=secret&submit=login` (正确)

**其他受益场景：**
- 搜索参数: `search=hello world&type=web`
- 评论内容: `comment=this is a comment&author=john`  
- 包含制表符/换行符的数据: `data=value\twith\ttabs&submit=save`

## 修改文件

- `helpers/http.py` - 在 `makeMessage` 函数中修复正则表达式模式

## 影响

此修复解决了一个关键bug，该bug阻止了最常见情况下的URL参数替换工作（查询字符串中的第一个参数）。这个改动是向后兼容的，不会影响其他参数位置的现有功能。

---

##  English Version

# Fix URL parameter replacement regex for query string starting parameters

## Problem Description

The URL parameter replacement feature fails to replace parameters that appear at the beginning of the query string due to an incorrect regex pattern.

**Example Issue:**
- URL: `GET /api/user?username=lucy&submit=data HTTP/1.1`
- Trying to replace: `username=newuser`
- Current behavior:  No replacement occurs
- Expected behavior: Should replace `username=lucy` with `username=newuser`

## Root Cause Analysis

The issue occurs during URL processing in the `makeMessage()` function:

1. **Original URL**: `GET /api/user?username=lucy&submit=data HTTP/1.1`
2. **After `url.split("?", 1)`**: query becomes `username=lucy&submit=data` (no leading `?`)
3. **Original regex**: `([?&])paramName=` expects `?username=` or `&username=`
4. **Actual query**: `username=lucy&...` (no leading `?` or `&`)

The regex pattern `([?&])paramName=[^&\s]*` only matches parameters preceded by `?` or `&`, but the first parameter has no preceding separator after URL splitting.

## Solution

Updated regex pattern from:
```python
pattern = r'([?&]){}=[^&\s]*'.format(re.escape(paramKey))
```

To:
```python
pattern = r'(^|[?&]){}=[^&]*'.format(re.escape(paramKey))
```

**Key changes:**
- Added `^|` to match string start (for first parameter)
- Simplified parameter value matching for better URL-encoded parameter support

## Files Modified
- `helpers/http.py` - Line ~58, updated regex in `makeMessage()` function

## Backward Compatibility
This change is fully backward compatible and doesn't affect existing functionality.
